### PR TITLE
Add utils for interpreting `Verbosity.Type` as Int, Bool

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLVerbosity"
 uuid = "a05b3ec9-34a1-438a-b0a1-c0adb433119f"
 authors = ["Jadon Clugston"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -92,6 +92,19 @@ macro SciMLMessage(f_or_message, verb, option, group)
         $(esc(f_or_message)), $(esc(verb)), $option, $group, $file, $line, $_module))
 end
 
+"""
+        `verbosity_to_int(verb::Verbosity.Type)`
+    Takes a `Verbosity.Type` and gives a corresponding integer value. 
+    Verbosity settings that use integers or enums that hold integers are relatively common.
+    This provides an interface so that these packages can be used with SciMLVerbosity. Each of the basic verbosity levels
+    are mapped to an integer. 
+
+    - None() => 0
+    - Info() => 1
+    - Warn() => 2
+    - Error() => 3
+    - Level(i) => i
+"""
 function verbosity_to_int(verb::Verbosity.Type)
     @match verb begin
         Verbosity.None() => 0
@@ -102,6 +115,13 @@ function verbosity_to_int(verb::Verbosity.Type)
     end
 end
 
+"""
+        `verbosity_to_bool(verb::Verbosity.Type)`
+    Takes a `Verbosity.Type` and gives a corresponding boolean value.
+    Verbosity settings that use booleans are relatively common.
+    This provides an interface so that these packages can be used with SciMLVerbosity.
+    If the verbosity is `Verbosity.None`, then `false` is returned. Otherwise, `true` is returned.
+"""
 function verbosity_to_bool(verb::Verbosity.Type)
     @match verb begin
         Verbosity.None() => false

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -92,6 +92,27 @@ macro SciMLMessage(f_or_message, verb, option, group)
         $(esc(f_or_message)), $(esc(verb)), $option, $group, $file, $line, $_module))
 end
 
+function verbosity_to_int(verb::Verbosity.Type)
+    @match verb begin
+        Verbosity.None() => 0
+        Verbosity.Info() => 1
+        Verbosity.Warn() => 2
+        Verbosity.Error() => 3
+        Verbosity.Level(i) => i
+    end
+end
+
+function verbosity_to_bool(verb::Verbosity.Type)
+    @match verb begin
+        Verbosity.None() => false
+        _ => true
+    end
+end
+
+
+
+
+
 function SciMLLogger(; info_repl=true, warn_repl=true, error_repl=true,
     info_file=nothing, warn_file=nothing, error_file=nothing)
     info_sink = isnothing(info_file) ? NullLogger() : FileLogger(info_file)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

It's relatively common for packages to use either an Int or a Bool to set verbosity levels. These utility functions provide an interface for those packages. This way users can use SciMLVerbosity to set the verbosity of these packages in a context where they're being used in a SciML package. 