### PR TITLE
Update CI to test on Julia 1, lts, and pre versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.11'
+          - '1'
           - 'lts'
           - 'pre'
         os:


### PR DESCRIPTION
## Summary
- Replace specific Julia version '1.11' with standard '1' in CI matrix
- Aligns with SciML ecosystem standards for testing on Julia 1, lts, and pre versions

## Test plan
- [x] Validate YAML syntax
- [ ] Verify CI passes on all Julia versions after merge

🤖 Generated with [Claude Code](https://claude.ai/code)